### PR TITLE
Creating the group name and artifact name to be able to publish to JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jfrog_version = '1.7.3'
         kotlin_version = '1.2.0-beta-88'
         // Release version of the artifact
-        release_version = '1.1.0.0'
+        release_version = '1.2.0.0'
     }
     repositories {
         maven {

--- a/gradle/deploy.settings
+++ b/gradle/deploy.settings
@@ -1,5 +1,5 @@
 gitUrl=git@github.com:missioncommand/cmapi-kotlin.git
-groupId=cmapi-kotlin
+groupId=cmapi
 id=cmapi-kotlin
 siteUrl=https://github.com/missioncommand/cmapi-kotlin
 description=A port of the Common Map API for the Kotlin language, supporting both Java and Javascript in a single baseline.


### PR DESCRIPTION
The artifact id and group id must be different to publish to JCenter
Updated the version as well